### PR TITLE
Improve risk (DEA Raid)

### DIFF
--- a/templates/game.js
+++ b/templates/game.js
@@ -1640,15 +1640,15 @@ function Game() {
 
     // Calculate and return the player's risk level
     function get_risk() { 
-        var rsk = 0;
+        var rsk = 0.5;
         for(var k in pd.clickers) { 
             if(pd.clickers[k].risk) { 
-                rsk += pd.clickers[k].risk * pd.clickers[k].amount;
+                rsk *= Math.pow(1 + pd.clickers[k].risk, pd.clickers[k].amount);
             }
         }
         for(var k in pd.sellers) { 
             if(pd.sellers[k].risk) { 
-                rsk += pd.sellers[k].risk * pd.sellers[k].amount;
+                rsk *= Math.pow(1 + pd.sellers[k].risk, pd.sellers[k].amount);
             }
         }
         return rsk;


### PR DESCRIPTION
Explanation of a possible risk calculation: 
Since we are in the meth business, risk start from 0.5.

Every time we purchase an facility, our risk increases or decreases proportional to the risk of the facility we have bought.  

Some examples:
    Default risk = 0.5 
    -> 50%

```
One +10% risk facility = 0.5 * (1 + 0.1) = 0.55 
-> 55%

Five +10% risk facilities = 0.5 * (1.1)^5 = 0.805255 
-> 81%

One -5% risk facility = 0.5 * (1 - 0.05) = 0.475 
-> 48%

Five -5% risk facilities = 0.5 * (0.95)^5 = 0.38689046875 
-> 39%

Five +10% risk facilities and five -5% risk facilities = 0.5 * (1.1)^5 * (0.95)^5 = 0.62309096882
-> 62%

In case we have 710 'Sleazy Lawyers' along with other the risk factors, the final risk somewhere around is 1.7e-100 instead of -19,432.5%    :-)
```
