### PR TITLE
Added another laundering tier + achievement (referring to Weyland-Yutani).

### DIFF
--- a/templates/game.js
+++ b/templates/game.js
@@ -1560,7 +1560,7 @@ function Game() {
                 'value':1,
                 'group':240,
                 'min_time':1,
-                'sid':'a20',
+                'sid':'a21',
             },
             'cheated_cash_1':{
                 'label':'Counterfeiter',


### PR DESCRIPTION
Not sure about the methodology used to determine the cost/rps levels so I went by ratios between previous levels. For this tier I left the rps upgrade amount roughly the same as the previous tier, but made the cost a bit higher, relatively speaking. Feel free to tweak/mutilate/reject as desired :)
