### PR TITLE
Add support for negative achievement requirements

### DIFF
--- a/templates/game.js
+++ b/templates/game.js
@@ -2967,7 +2967,7 @@ function Game() {
             if((val === true)&&(val === a.required)) { 
                 unlock_achievement(k);
             }
-            else if((val)&&(val >= a.required)) {
+            else if((val)&&((a.required >= 0 && val >= a.required)||(a.required < 0 && val <= a.required))) {
                 unlock_achievement(k);
             } 
         }


### PR DESCRIPTION
This adds support for requiring negative values for achievements, so that achievements for IRS & DEA risk can be added.
