### PR TITLE
Added made/sold x batches per click to the stats page

### DIFF
--- a/templates/game.js
+++ b/templates/game.js
@@ -2876,6 +2876,7 @@ function Game() {
                 pd.stats.bought_upgrades += 1;
             }
         }
+        
         if(active_tab != 'misc') { return; }
         $('#hand_made_widgets').html(pretty_bigint(pd.stats.hand_made_widgets));
         $('#made_widgets').html(pretty_bigint(pd.stats.made_widgets));
@@ -2884,6 +2885,8 @@ function Game() {
         $('#total_cash').html(pretty_bigint(pd.stats.total_cash));
         $('#bought_upgrades').html(pretty_int(pd.stats.bought_upgrades));
         $('#time_played').html(pretty_int(pd.stats.seconds_played));
+        $('#click_sell_amount').html(pretty_int(pd.sell_amount));
+        $('#click_make_amount').html(pretty_int(pd.make_amount));
     }
 
     /****************************************************************************** 

--- a/templates/index.html
+++ b/templates/index.html
@@ -266,6 +266,8 @@ $(document).ready(function() {
                 <li>Total upgrades purchased: <b><span id="bought_upgrades">0</span></b></li>
                 <li>Total cash earned: <b>$<span id="total_cash">0</span></b></li>
                 <li>Seconds spent playing: <b><span id="time_played">0</span></b></li>
+                <li>Batches made per click: <b><span id="click_make_amount">0</span></b></li>
+                <li>Batches sold per click: <b><span id="click_sell_amount">0</span></b></li>
             </ul>    
         </div>
 


### PR DESCRIPTION
The game displays, easily, how much money you make second, but it doesn't display how many batches you're selling per second. So, I added a batches sold per click and batches made per click (because one without the other just looked awkward) to the stats list on the options and stats tab.
