### PR TITLE
Inserted a new formula for calculating item_cost, fixing issue #117

### DIFF
--- a/templates/game.js
+++ b/templates/game.js
@@ -1997,7 +1997,7 @@ function Game() {
         var cst = Math.pow(sc1.base_cost, exponent) * sc1.amount;
         //To ensure an item always has a sell cost.
         if(cst > Number.MAX_VALUE){
-            cst = Number.MAX_VALUE
+            cst = Number.MAX_VALUE;
         }
         return cst;
     }


### PR DESCRIPTION
I've created a new formula to calculate the cost of items, the new formula is:

base_cost^(1 + ((amount + 1) \* 0.0075)^2) \* (amount + 1)

The old formula slowly decreased the amount added to the new cost when more and more items of the same type were bought, so that the price gap between the 4,999th and 5,000th item was 0.04% as opposed to the increase between the 1st and 2nd item, which is generally more than 150%. Long story short, currently, if people were to buy enough of one item, they would eventually reach a point where there would be no change in price.

With the new formula, the price jump for the first few items is about 100%, 50%, 33%, 25%, and so on for about the first 30 items (reaching a min of about 3.7%) this is due to the last ' ... \* (amount + 1)' which causes the large price jump in a way similar to the original formula, after the first 30 items, the main part of the new formula kicks in and we start to see a slow exponential increase, this means that users will never reach the point of "I can buy everything, yays".

So yeah, bitches.
